### PR TITLE
changed the magnify glass icon in the header to plain text

### DIFF
--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -3,24 +3,8 @@ import { useOktaAuth } from '@okta/okta-react';
 import { useHistory } from 'react-router-dom';
 
 import cityspireLogo from '../../assets/imgs/cityspireLogo.png';
-import {
-  Row,
-  Col,
-  Menu,
-  Dropdown,
-  Avatar,
-  Button,
-  Image,
-  Input,
-  Space,
-  Divider,
-} from 'antd';
-import {
-  UserOutlined,
-  DownOutlined,
-  SearchOutlined,
-  AudioOutlined,
-} from '@ant-design/icons';
+import { Row, Col, Menu, Dropdown, Avatar, Image, Space, Divider } from 'antd';
+import { UserOutlined, DownOutlined } from '@ant-design/icons';
 
 const HeaderStyle = {
   display: 'flex',
@@ -32,7 +16,7 @@ const HeaderStyle = {
 };
 
 const Header = () => {
-  const { authService, authState } = useOktaAuth();
+  const { authService } = useOktaAuth();
   const [userInfo, setUserInfo] = useState(null);
   // eslint-disable-next-line
   const [memoAuthService] = useMemo(() => [authService], []);

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -127,9 +127,7 @@ const Header = () => {
 
             <Divider type="vertical" />
             <a href="/" style={{ color: 'grey' }}>
-              <SearchOutlined
-                style={{ cursor: 'pointer', fontSize: '1.15rem' }}
-              />
+              Map View
             </a>
             <Divider type="vertical" />
             {/* BEG: sdh */}


### PR DESCRIPTION
The header had two 'search' options and there was nothing that distinguished the 'map search' from a regular search. To improve user experience, the magnify glass icon in the header was changed to plain text, it now says 'Map View'. 